### PR TITLE
testing analytic gradients for rungekutta Method with DERIVEST package

### DIFF
--- a/demo/fiveLinkBiped/DEV_rungeKutta_grad.m
+++ b/demo/fiveLinkBiped/DEV_rungeKutta_grad.m
@@ -132,12 +132,15 @@ switch method
         %
         % Question: Is this error due to a problem with the implementation,
         % or just some numerical artifact?
+        % Update: Seems to be a problem with matlab's finite difference 
+        % calculation. Added objective gradient tests with DERIVEST package
+        % to rungeKutta.m
         
         problem.options(1).method = 'rungeKutta'; % Select the transcription method
         problem.options(1).defaultAccuracy = 'low';
         problem.options(1).nlpOpt.GradConstr = 'on';
         problem.options(1).nlpOpt.GradObj = 'on';
-        problem.options(1).nlpOpt.DerivativeCheck = 'on';
+        problem.options(1).nlpOpt.DerivativeCheck = 'off';
         
         problem.options(2).method = 'rungeKutta'; % Select the transcription method
         problem.options(2).defaultAccuracy = 'low';
@@ -150,6 +153,7 @@ switch method
         % Let's try putting in some totally random initial guess. 
         % ...
         % This seems to throw an error too.
+        % Update: With DERIVEST for checking gradients, this test passes.
         
         nGridGuess = 10;
         problem.guess.time = linspace(0, 0.5+0.6*rand(1), nGridGuess);

--- a/demo/pendulum/DEV_rk4_grad.m
+++ b/demo/pendulum/DEV_rk4_grad.m
@@ -63,7 +63,7 @@ problem.options(1).nlpOpt = optimset(...
     'DerivativeCheck','on',...
     'MaxFunEvals',1e5);   %Fmincon automatically checks derivatives
 problem.options(1).method = 'rungeKutta';
-problem.options(1).defaultAccuracy = 'medium';
+problem.options(1).defaultAccuracy = 'low';
 
 %%%% SECOND ITERATION
 problem.options(2) = problem.options(1);

--- a/demo/pendulum/obj_boundObj.m
+++ b/demo/pendulum/obj_boundObj.m
@@ -4,7 +4,7 @@ function [dObj, dObjGrad] = obj_boundObj(xF,xF_des)
 % This is a sample bound objective for testing analtyic gradients.
 
 % weight on bound cost
-Q = diag([100, 1]);
+Q = 100000*diag([1, 1]);
 
     % add cost for being away from final desired state.
     % NOTE: probably need to angle wrapping


### PR DESCRIPTION
Replicated essentially the same type of gradient checking function in matlab optimization toolbox, but instead with functions from the DERIVEST package for more accurate numerical differentiation.

Added a bound objective to the pendulum example with a huge cost. This causes matlabs's finite difference calculation to fail. To compare matlab's finite difference calculation with DERIVEST, comment out line 102 in rungeKutta.m

Note, the DERIVEST gradient checking function takes about 10 minutes to run for the 5link walker example.