### PR TITLE
Analytic gradients for path objective with Multiple Shooting (rungeKu…

### DIFF
--- a/demo/pendulum/DEV_pathObjective.m
+++ b/demo/pendulum/DEV_pathObjective.m
@@ -1,0 +1,19 @@
+function [obj, objGrad] = pathObjective(x,u)
+% [obj, objGrad] = pathObjective(u)
+%
+% Computes the objective function (and gradients) for the simple pendulum
+%
+
+obj = u.^2 + x(2,:).^2;
+
+if nargout == 2  % Analytic gradients
+    nTime = length(u);
+    
+    objGrad = zeros(4,nTime); %4 = [time + angle + rate + torque];
+    
+    objGrad(3,:) = 2*x(2,:);
+    objGrad(4,:) = 2*u;  %gradient obj wrt u
+    
+end
+
+end

--- a/demo/pendulum/DEV_rk4_grad.m
+++ b/demo/pendulum/DEV_rk4_grad.m
@@ -16,7 +16,7 @@ p.c = 0.1;  % Normalized damping constant
 
 % User-defined dynamics and objective functions
 problem.func.dynamics = @(t,x,u)( dynamics(x,u,p) );
-problem.func.pathObj = @(t,x,u)( pathObjective(u) );
+problem.func.pathObj = @(t,x,u)( DEV_pathObjective(x,u) );
 
 % bound objective for testing
 xF_target = [pi;0];
@@ -50,7 +50,7 @@ problem.options(1).nlpOpt = optimset(...
     'MaxFunEvals',1e5);   %Fmincon automatically checks derivatives
 problem.options(1).method = 'rungeKutta';
 problem.options(1).defaultAccuracy = 'low';
-problem.options(1).rungeKutta.AdaptiveDerivativeCheck = 'on';
+problem.options(1).rungeKutta.AdaptiveDerivativeCheck = 'off';
 
 %%%% SECOND ITERATION
 problem.options(2) = problem.options(1);


### PR DESCRIPTION
…tta) method

Analytic gradients for path objectives that include cost on the state are now supported. But only tested on the pendulum example. However, as the code is currently written, the rungeKutta function assumes the dynamics and cost do not depend explicitly on time, t.

Does t depend on the decision variables at all? In discrete time 
t = n dt
dt = (tF - t0) / N
t = n (tF - t0 ) / N
It seems t depends on decision vars t0 and tF, in which case that dependence would need to be included in the gradients as well.