### PR TITLE
Replaced getDefaultPlotColors with get(gca,'colororder')

### DIFF
--- a/demo/fiveLinkBiped/RESULTS.m
+++ b/demo/fiveLinkBiped/RESULTS.m
@@ -255,7 +255,7 @@ xlabel('time')
 ylabel('joint torques')
 
 figure(3); clf;
-Color = getDefaultPlotColors();
+Color = get(gca,'colororder');
 for i=1:5
     iLeft = 2*i-1;
     iRight = iLeft + 1;


### PR DESCRIPTION
On master (MATLAB R2020a) `demo/fiveLinkBiped/RESULTS.m` fails on line 258 due to 
```
Unrecognized function or variable 'getDefaultPlotColors'.

Error in RESULTS (line 258)
Color = getDefaultPlotColors();
```

Fix is from https://www.mathworks.com/matlabcentral/answers/26249-default-figure-color-order#answer_152313

and resulting figure looks like: 
![image](https://github.com/MatthewPeterKelly/OptimTraj/assets/35812036/528826c7-2959-4ae3-b0d8-245bd3361551)
